### PR TITLE
Fix wrong step edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/Urigo/tortilla.git"
   },
   "scripts": {
-    "test": "TORTILLA_STDIO=ignore mocha tests/test --timeout=30000"
+    "test": "TORTILLA_STDIO=ignore mocha tests/test --timeout=60000"
   },
   "dependencies": {
     "fs-extra": "^0.30.0",

--- a/skeleton/.tortilla/step.js
+++ b/skeleton/.tortilla/step.js
@@ -194,7 +194,7 @@ function getStepBase(step) {
   }
 
   var hash = Git.recentCommit([
-    '--grep=^Step ' + step,
+    '--grep=^Step ' + step + ':',
     '--format=%h'
   ]);
 

--- a/tests/step-test.js
+++ b/tests/step-test.js
@@ -170,7 +170,12 @@ describe('Step', function () {
 
     it('should edit the provided step', function () {
       this.npm.step(['push', '-m', 'target', '--allow-empty']);
-      this.npm.step(['push', '-m', 'dummy', '--allow-empty']);
+      
+      let size = 10;
+      while (size--) {
+        this.npm.step(['push', '-m', 'dummy', '--allow-empty']);
+      }
+
       this.npm.step(['edit', '1.1']);
 
       const isRebasing = this.git.rebasing();


### PR DESCRIPTION
`npm run step -- edit "1.1"` gives `1.11` instead of `1.1`

@DAB0mB I increased mocha's timeout to `60000` because the test pushes 11 steps, but you can change it if you want to.
