### PR TITLE
Fixed documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Initializes Tortilla essentials in the provided project.
 
 For more information see the [manuals](#manuals) section.
 
-**command:** `tortilla render manual [step]`
+**command:** `tortilla manual render [step]`
 
 Renders specified manual view.
 


### PR DESCRIPTION
The correct syntax is `tortilla manual render [step]` and not `tortilla render manual [step]`.